### PR TITLE
Update Reactive UI and Splat

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreVersion>9.0.2</CoreVersion>
+    <CoreVersion>9.0.3</CoreVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
@@ -50,7 +50,7 @@
   <ItemGroup>
     <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.13.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net8')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.12">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
@@ -24,10 +24,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net8')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.12">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Drawing" Version="20.1.63" />
-    <PackageReference Include="ReactiveUI.WinForms" Version="20.1.63" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.2.22" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="20.2.45" />
+    <PackageReference Include="ReactiveUI.WinForms" Version="20.2.45" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.WinUI" Version="20.1.63" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.2.22" />
+    <PackageReference Include="ReactiveUI.WinUI" Version="20.2.45" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Drawing" Version="20.1.63" />
-    <PackageReference Include="ReactiveUI.WPF" Version="20.1.63" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.2.22" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="20.2.45" />
+    <PackageReference Include="ReactiveUI.WPF" Version="20.2.45" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
+++ b/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes several updates to package versions across multiple project files to ensure compatibility and leverage the latest features and bug fixes. The changes primarily involve updating dependencies in various `.csproj` files.

Dependency updates:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL33-R33): Updated `CoreVersion` to `9.0.3` and `Roslynator.Analyzers` to `4.13.1`. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL33-R33) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL53-R53)
* [`Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj`](diffhunk://#diff-64643b43feada1a782763fb0d79532b89dfbf98d989c942a97e651b63fbc96dfL26-R29): Updated `Microsoft.AspNetCore.Identity.UI`, `Microsoft.AspNetCore.Identity.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.Sqlite`, and `Microsoft.EntityFrameworkCore.Tools` to `8.0.14`.
* [`Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj`](diffhunk://#diff-90082d269faebbe96832cfba09b841ebd68837128f862a2e1e15a2c9a035c353L27-R30): Updated `Microsoft.AspNetCore.Identity.UI`, `Microsoft.AspNetCore.Identity.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, and `Microsoft.EntityFrameworkCore.Tools` to `8.0.14`.
* `Extensions.Hosting.ReactiveUI.WinForms.csproj`, `Extensions.Hosting.ReactiveUI.WinUI.csproj`, and `Extensions.Hosting.ReactiveUI.Wpf.csproj`: Updated `ReactiveUI.Drawing` and `ReactiveUI.WinForms`/`ReactiveUI.WinUI`/`ReactiveUI.WPF` to `20.2.45`, and `Splat.Microsoft.Extensions.DependencyInjection` to `15.3.1`. [[1]](diffhunk://#diff-64deb6dcf060e22ca1879ad6ec0653ea01ddc6bdcfad64f6079a6b9d850d3095L13-R15) [[2]](diffhunk://#diff-3f2548740a098105ad24cdea1c4b86b872c5f821b7532b943b635e1e64faeb68L15-R16) [[3]](diffhunk://#diff-64c1fb7463f66d2e3b57e3de3883c5f14b7658ea38ec933ae0ef280a8185e27cL13-R15)
* [`Extensions.Hosting.WinUI.csproj`](diffhunk://#diff-eca43a04fb09da7895e5805cdc5b40e394b288a6186248615d3f9e13db1e16e7L14-R14): Updated `Microsoft.WindowsAppSDK` to `1.6.250228001`.