### PR TITLE
Add IApplicationBuilder configuration access

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreVersion>9.0.3</CoreVersion>
+    <CoreVersion>9.0.4</CoreVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net8')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -138,6 +139,29 @@ public static class HostBuilderEntityFrameworkCoreExtensions
             configureWebHost(webBuilder)
                 .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
                 .Configure(app => app.Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                .ConfigureServices((context, services) => configureServices(context, services)));
+    }
+
+    /// <summary>
+    /// Uses the web host services.
+    /// </summary>
+    /// <param name="hostBuilder">The host builder.</param>
+    /// <param name="configureServices">The configure services.</param>
+    /// <param name="configureWebHost">The configure web host.</param>
+    /// <param name="configureApp">The configure application, e.g. app.UseEndpoints.</param>
+    /// <param name="validateScopes">if set to <c>true</c> [validate scopes].</param>
+    /// <returns>
+    /// IHostBuilder.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException">hostBuilder.</exception>
+    public static IHostBuilder UseWebHostServices(this IHostBuilder hostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> configureApp, bool validateScopes = false)
+    {
+        ArgumentNullException.ThrowIfNull(hostBuilder);
+
+        return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
+            configureWebHost(webBuilder)
+                .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
+                .Configure(app => configureApp(app).Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
                 .ConfigureServices((context, services) => configureServices(context, services)));
     }
 }

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/HostBuilderEntityFrameworkCoreExtensions.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
@@ -24,10 +24,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net8')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs
@@ -145,20 +145,20 @@ public static class HostBuilderEntityFrameworkCoreExtensions
     /// <param name="hostBuilder">The host builder.</param>
     /// <param name="configureServices">The configure services.</param>
     /// <param name="configureWebHost">The configure web host.</param>
-    /// <param name="coonfigureApp">The coonfigure application.</param>
+    /// <param name="configureApp">The configure application, e.g. app.UseEndpoints.</param>
     /// <param name="validateScopes">if set to <c>true</c> [validate scopes].</param>
     /// <returns>
     /// IHostBuilder.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">hostBuilder.</exception>
-    public static IHostBuilder UseWebHostServices(this IHostBuilder hostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> coonfigureApp, bool validateScopes = false)
+    public static IHostBuilder UseWebHostServices(this IHostBuilder hostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> configureApp, bool validateScopes = false)
     {
         ArgumentNullException.ThrowIfNull(hostBuilder);
 
         return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
             configureWebHost(webBuilder)
                 .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
-                .Configure(app => coonfigureApp(app).Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                .Configure(app => configureApp(app).Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
                 .ConfigureServices((context, services) => configureServices(context, services)));
     }
 }

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/HostBuilderEntityFrameworkCoreExtensions.cs
@@ -138,4 +138,27 @@ public static class HostBuilderEntityFrameworkCoreExtensions
                 .Configure(app => app.Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
                 .ConfigureServices((context, services) => configureServices(context, services)));
     }
+
+    /// <summary>
+    /// Uses the web host services.
+    /// </summary>
+    /// <param name="hostBuilder">The host builder.</param>
+    /// <param name="configureServices">The configure services.</param>
+    /// <param name="configureWebHost">The configure web host.</param>
+    /// <param name="coonfigureApp">The coonfigure application.</param>
+    /// <param name="validateScopes">if set to <c>true</c> [validate scopes].</param>
+    /// <returns>
+    /// IHostBuilder.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException">hostBuilder.</exception>
+    public static IHostBuilder UseWebHostServices(this IHostBuilder hostBuilder, Action<WebHostBuilderContext, IServiceCollection> configureServices, Func<IWebHostBuilder, IWebHostBuilder> configureWebHost, Func<IApplicationBuilder, IApplicationBuilder> coonfigureApp, bool validateScopes = false)
+    {
+        ArgumentNullException.ThrowIfNull(hostBuilder);
+
+        return hostBuilder.ConfigureWebHostDefaults(webBuilder =>
+            configureWebHost(webBuilder)
+                .UseDefaultServiceProvider(options => options.ValidateScopes = validateScopes)
+                .Configure(app => coonfigureApp(app).Run(async (_) => await Task.CompletedTask)) // Dummy app.Run to prevent 'No application service provider was found' error.
+                .ConfigureServices((context, services) => configureServices(context, services)));
+    }
 }

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <PackageDescription>This extension adds ReactiveUI support to generic host based dotnet core 6.0 / 8.0 WinUI applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this reactive MVVM framework.</PackageDescription>
+    <PackageDescription>This extension adds ReactiveUI support to generic host based dotnet core 8.0 / 9.0 WinUI applications. With this you can enhance your application with a UI, and use all the services provided by the generic host like DI, logging etc, together with this reactive MVVM framework.</PackageDescription>
     <PackageId>CP.Extensions.Hosting.ReactiveUI.WinUI</PackageId>
   </PropertyGroup>
 

--- a/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
+++ b/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250401001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to dependencies, new functionality for `UseWebHostServices`, and minor project metadata changes. The most significant changes involve upgrading package versions across multiple projects and adding a new overload for the `UseWebHostServices` method to enhance configuration flexibility.

### Dependency Updates:
* Updated `CoreVersion` from `9.0.3` to `9.0.4` in `Directory.Build.props` to ensure compatibility with the latest core version.
* Updated multiple package references (e.g., `Microsoft.AspNetCore.Identity.UI`, `Microsoft.EntityFrameworkCore`) from version `8.0.14` to `8.0.15` in `Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj` and `Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj` for improved stability and bug fixes. [[1]](diffhunk://#diff-64643b43feada1a782763fb0d79532b89dfbf98d989c942a97e651b63fbc96dfL26-R29) [[2]](diffhunk://#diff-90082d269faebbe96832cfba09b841ebd68837128f862a2e1e15a2c9a035c353L27-R30)
* Upgraded `Microsoft.WindowsAppSDK` from version `1.6.250228001` to `1.7.250401001` in `Extensions.Hosting.WinUI.csproj` for the latest features and fixes.

### New Functionality:
* Added a new overload for the `UseWebHostServices` method in both `HostBuilderEntityFrameworkCoreExtensions.cs` files to support additional configuration options for web host, application, and scope validation. [[1]](diffhunk://#diff-ea5f3cc3cb2fd633d0838d812b7bed72ed94fb42f67476a8809de467e5198205R143-R165) [[2]](diffhunk://#diff-04d69b2b013453860acf5a0852c930993562e41d029ffbd9c7060959e06d99dcR141-R163)

### Metadata Updates:
* Updated the package description in `Extensions.Hosting.ReactiveUI.WinUI.csproj` to reflect support for .NET Core 8.0 and 9.0 instead of 6.0 and 8.0.