### PR TITLE
Update ReactiveUI and Splat dependencies and refactor DI setup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreVersion>9.0.5</CoreVersion>
+    <CoreVersion>9.0.9</CoreVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
@@ -50,7 +50,7 @@
   <ItemGroup>
     <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.14.0" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite/Extensions.Hosting.Identity.EntityFrameworkCore.Sqlite.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(CoreVersion)" />
   </ItemGroup>
 

--- a/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Extensions.Hosting.Identity.EntityFrameworkCore/Extensions.Hosting.Identity.EntityFrameworkCore.SqlServer.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(CoreVersion)" />
     <PackageReference Include="System.Formats.Asn1" Version="$(CoreVersion)" />
   </ItemGroup>

--- a/src/Extensions.Hosting.Plugins/Extensions.Hosting.Plugins.csproj
+++ b/src/Extensions.Hosting.Plugins/Extensions.Hosting.Plugins.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(CoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(CoreVersion)" />
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Hosting.Reactive.Example/Extensions.Hosting.Reactive.Example.csproj
+++ b/src/Extensions.Hosting.Reactive.Example/Extensions.Hosting.Reactive.Example.csproj
@@ -14,8 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
     <PackageReference Include="NuGet.Protocol" Version="6.14.0" />
   </ItemGroup>
 

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/Extensions.Hosting.ReactiveUI.WinForms.csproj
@@ -10,9 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Drawing" Version="20.2.45" />
-    <PackageReference Include="ReactiveUI.WinForms" Version="20.2.45" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
+    <PackageReference Include="Splat" Version="16.2.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="16.2.1" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="21.0.1" />
+    <PackageReference Include="ReactiveUI.WinForms" Version="21.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
@@ -4,7 +4,9 @@
 
 using Microsoft.Extensions.Hosting;
 using ReactiveUI;
+using ReactiveUI.Builder;
 using Splat;
+using Splat.Builder;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
@@ -22,10 +24,12 @@ public static class HostBuilderReactiveUiExtensions
     public static IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder hostBuilder) =>
         hostBuilder.ConfigureServices((serviceCollection) =>
         {
-            serviceCollection.UseMicrosoftDependencyResolver();
-            var resolver = Locator.CurrentMutable;
+            var resolver = AppLocator.CurrentMutable;
+            resolver.CreateReactiveUIBuilder()
+                .UsingSplatModule(new MicrosoftDependencyResolverModule(serviceCollection))
+                .WithWinForms()
+                .Build();
             resolver.InitializeSplat();
-            resolver.InitializeReactiveUI();
         });
 
     /// <summary>

--- a/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinForms/HostBuilderReactiveUiExtensions.cs
@@ -24,12 +24,11 @@ public static class HostBuilderReactiveUiExtensions
     public static IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder hostBuilder) =>
         hostBuilder.ConfigureServices((serviceCollection) =>
         {
-            var resolver = AppLocator.CurrentMutable;
-            resolver.CreateReactiveUIBuilder()
-                .UsingSplatModule(new MicrosoftDependencyResolverModule(serviceCollection))
+            serviceCollection.UseMicrosoftDependencyResolver();
+            AppLocator.CurrentMutable.CreateReactiveUIBuilder()
                 .WithWinForms()
+                .WithRegistration(r => r.InitializeSplat())
                 .Build();
-            resolver.InitializeSplat();
         });
 
     /// <summary>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/Extensions.Hosting.ReactiveUI.WinUI.csproj
@@ -12,8 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.WinUI" Version="20.2.45" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
+    <PackageReference Include="Splat" Version="16.2.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="16.2.1" />
+    <PackageReference Include="ReactiveUI.WinUI" Version="21.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
-using ReactiveUI;
+using ReactiveUI.Builder;
 using Splat;
+using Splat.Builder;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
@@ -22,10 +23,12 @@ public static class HostBuilderReactiveUiExtensions
     public static IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder hostBuilder) =>
         hostBuilder.ConfigureServices((serviceCollection) =>
         {
-            serviceCollection.UseMicrosoftDependencyResolver();
-            var resolver = Locator.CurrentMutable;
+            var resolver = AppLocator.CurrentMutable;
+            resolver.CreateReactiveUIBuilder()
+                .UsingSplatModule(new MicrosoftDependencyResolverModule(serviceCollection))
+                .WithWinUI()
+                .Build();
             resolver.InitializeSplat();
-            resolver.InitializeReactiveUI();
         });
 
     /// <summary>

--- a/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.WinUI/HostBuilderReactiveUiExtensions.cs
@@ -23,12 +23,11 @@ public static class HostBuilderReactiveUiExtensions
     public static IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder hostBuilder) =>
         hostBuilder.ConfigureServices((serviceCollection) =>
         {
-            var resolver = AppLocator.CurrentMutable;
-            resolver.CreateReactiveUIBuilder()
-                .UsingSplatModule(new MicrosoftDependencyResolverModule(serviceCollection))
+            serviceCollection.UseMicrosoftDependencyResolver();
+            AppLocator.CurrentMutable.CreateReactiveUIBuilder()
                 .WithWinUI()
+                .WithRegistration(r => r.InitializeSplat())
                 .Build();
-            resolver.InitializeSplat();
         });
 
     /// <summary>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/Extensions.Hosting.ReactiveUI.Wpf.csproj
@@ -10,9 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Drawing" Version="20.2.45" />
-    <PackageReference Include="ReactiveUI.WPF" Version="20.2.45" />
-    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
+    <PackageReference Include="Splat" Version="16.2.1" />
+    <PackageReference Include="ReactiveUI.Drawing" Version="21.0.1" />
+    <PackageReference Include="ReactiveUI.WPF" Version="21.0.1" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="16.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
-using ReactiveUI;
+using ReactiveUI.Builder;
 using Splat;
+using Splat.Builder;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
 namespace ReactiveMarbles.Extensions.Hosting.ReactiveUI;
@@ -22,10 +23,12 @@ public static class HostBuilderReactiveUiExtensions
     public static IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder hostBuilder) =>
         hostBuilder.ConfigureServices((serviceCollection) =>
         {
-            serviceCollection.UseMicrosoftDependencyResolver();
-            var resolver = Locator.CurrentMutable;
+            var resolver = AppLocator.CurrentMutable;
+            resolver.CreateReactiveUIBuilder()
+                .WithWpf()
+                .UsingSplatModule(new MicrosoftDependencyResolverModule(serviceCollection))
+                .Build();
             resolver.InitializeSplat();
-            resolver.InitializeReactiveUI();
         });
 
     /// <summary>

--- a/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
+++ b/src/Extensions.Hosting.ReactiveUI.Wpf/HostBuilderReactiveUiExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Hosting;
+using ReactiveUI;
 using ReactiveUI.Builder;
 using Splat;
 using Splat.Builder;
@@ -23,12 +24,11 @@ public static class HostBuilderReactiveUiExtensions
     public static IHostBuilder ConfigureSplatForMicrosoftDependencyResolver(this IHostBuilder hostBuilder) =>
         hostBuilder.ConfigureServices((serviceCollection) =>
         {
-            var resolver = AppLocator.CurrentMutable;
-            resolver.CreateReactiveUIBuilder()
+            serviceCollection.UseMicrosoftDependencyResolver();
+            AppLocator.CurrentMutable.CreateReactiveUIBuilder()
                 .WithWpf()
-                .UsingSplatModule(new MicrosoftDependencyResolverModule(serviceCollection))
+                .WithRegistration(r => r.InitializeSplat())
                 .Build();
-            resolver.InitializeSplat();
         });
 
     /// <summary>

--- a/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
+++ b/src/Extensions.Hosting.WinUI/Extensions.Hosting.WinUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250513003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request mainly updates package dependencies across several projects to their latest versions and modernizes the initialization of Splat and ReactiveUI in the WinForms, WinUI, and WPF host builder extension methods. The changes improve compatibility, maintainability, and leverage new features from updated libraries.

Dependency updates:

* Updated core and analyzer package versions in `Directory.Build.props`, including `CoreVersion` to `9.0.9` and `Roslynator.Analyzers` to `4.14.0`. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL33-R33) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL53-R53)
* Updated various project dependencies to the latest versions, such as `Splat`, `ReactiveUI.*`, `System.Reactive`, and `Microsoft.WindowsAppSDK` in their respective `.csproj` files. [[1]](diffhunk://#diff-d6206ccdff39fe2384e6dbfc0b07cbf27af5eff94f8e2475504beadbe1fa9924L13-R13) [[2]](diffhunk://#diff-64deb6dcf060e22ca1879ad6ec0653ea01ddc6bdcfad64f6079a6b9d850d3095L13-R16) [[3]](diffhunk://#diff-3f2548740a098105ad24cdea1c4b86b872c5f821b7532b943b635e1e64faeb68L15-R17) [[4]](diffhunk://#diff-64c1fb7463f66d2e3b57e3de3883c5f14b7658ea38ec933ae0ef280a8185e27cL13-R16) [[5]](diffhunk://#diff-eca43a04fb09da7895e5805cdc5b40e394b288a6186248615d3f9e13db1e16e7L14-R14)
* Removed unused `Newtonsoft.Json` package references from several projects. [[1]](diffhunk://#diff-64643b43feada1a782763fb0d79532b89dfbf98d989c942a97e651b63fbc96dfL11) [[2]](diffhunk://#diff-90082d269faebbe96832cfba09b841ebd68837128f862a2e1e15a2c9a035c353L11) [[3]](diffhunk://#diff-b4aafcf98df18cd3625572126aeccf726d6d65978a2cfcf90da4f514c1d58fe2L17-R17)

Modernization of Splat/ReactiveUI initialization:

* Refactored `ConfigureSplatForMicrosoftDependencyResolver` extension methods in WinForms, WinUI, and WPF projects to use the new `AppLocator.CurrentMutable.CreateReactiveUIBuilder()` API, replacing direct calls to `InitializeSplat` and `InitializeReactiveUI`. [[1]](diffhunk://#diff-1c6ddee50873258a14ca97c4e014ec620fcda5aa1e548e02b96ad621690d7e67L26-R31) [[2]](diffhunk://#diff-7623e2ed7a4c1dbfa8374d2ff222cde219c6d4163d52a42b50307eb723f583a7L26-R30) [[3]](diffhunk://#diff-3c2a447fedbb188909325837f7127b49f4c6b87887c82bb14a23f2feb323b0fdL26-R31)
* Added necessary `using` statements for the new builder APIs in the corresponding files. [[1]](diffhunk://#diff-1c6ddee50873258a14ca97c4e014ec620fcda5aa1e548e02b96ad621690d7e67R7-R9) [[2]](diffhunk://#diff-7623e2ed7a4c1dbfa8374d2ff222cde219c6d4163d52a42b50307eb723f583a7L6-R8) [[3]](diffhunk://#diff-3c2a447fedbb188909325837f7127b49f4c6b87887c82bb14a23f2feb323b0fdR7-R9)

These changes ensure the codebase stays up to date with the latest library improvements and best practices.